### PR TITLE
Add paid invoices graph to user dashboard

### DIFF
--- a/src/app/dashboard/_components/DashboardBlocks.tsx
+++ b/src/app/dashboard/_components/DashboardBlocks.tsx
@@ -47,7 +47,7 @@ export default async function DashboardBlocks() {
   const { invoiceData, pendingInvoices, paidInvoices } = await getData(user);
 
   return (
-    <div className="grid w-full gap-4 mx-auto md:grid-cols-2 lg:grid-cols-4 md:gap-8 max-w-screen-2xl">
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 md:gap-8">
       <Card>
         <CardHeader className="flex flex-row items-center justify-between pb-0 space-y-0">
           <CardTitle className="text-sm font-medium">Total Revenue</CardTitle>
@@ -56,11 +56,20 @@ export default async function DashboardBlocks() {
         <CardContent>
           <h2 className="text-3xl font-extrabold">
             $
-            {invoiceData.reduce(
-              (acc, invoice) => acc + Number(invoice.total),
-              0
-            )}
+            {new Intl.NumberFormat("en-US", {
+              notation: "standard",
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            })
+              .format(
+                invoiceData.reduce(
+                  (acc, invoice) => acc + Number(invoice.total),
+                  0
+                )
+              )
+              .replace(/^(\d{2})(\d{3})$/, "$1,$2")}
           </h2>
+
           <p className="mt-1 text-xs text-muted-foreground">
             Based on the last 30 days
           </p>

--- a/src/app/dashboard/_components/Graph.tsx
+++ b/src/app/dashboard/_components/Graph.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { Line, LineChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
+
+interface GraphProps {
+  data: {
+    date: string;
+    amount: number;
+  }[];
+}
+
+export default function Graph({ data }: GraphProps) {
+  return (
+    <ChartContainer
+      config={{
+        amount: {
+          label: "Amount",
+          color: "hsl(var(--primary))",
+        },
+      }}
+      className="min-h-[300px]"
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data}>
+          <XAxis dataKey="date" />
+          <YAxis />
+          <ChartTooltip content={<ChartTooltipContent indicator="line" />} />
+          <Line
+            type="monotone"
+            dataKey="amount"
+            stroke="hsl(var(--primary))"
+            strokeWidth={2}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ChartContainer>
+  );
+}

--- a/src/app/dashboard/_components/InvoiceGraph.tsx
+++ b/src/app/dashboard/_components/InvoiceGraph.tsx
@@ -1,0 +1,79 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import prisma from "@/lib/prisma";
+import { getSession } from "@/utils/session";
+import Graph from "./Graph";
+
+async function getInvoices(userId: string) {
+  const rawData = await prisma.invoice.findMany({
+    where: {
+      status: "PAID",
+      userId: userId,
+      createdAt: {
+        lte: new Date(),
+        gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+      },
+    },
+    select: {
+      createdAt: true,
+      total: true,
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+  });
+
+  const aggregatedData = rawData.reduce(
+    (acc: { [key: string]: number }, curr) => {
+      const date = new Date(curr.createdAt).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      });
+
+      acc[date] = (acc[date] || 0) + Number(curr.total);
+
+      return acc;
+    },
+    {}
+  );
+
+  const transformedData = Object.entries(aggregatedData)
+    .map(([date, amount]) => ({
+      date,
+      amount,
+      originalDate: new Date(date + ", " + new Date().getFullYear()),
+    }))
+    .sort((a, b) => a.originalDate.getTime() - b.originalDate.getTime())
+    .map(({ date, amount }) => ({
+      date,
+      amount,
+    }));
+
+  return transformedData;
+}
+
+export default async function InvoiceGraph() {
+  const session = await getSession();
+  const user = session?.user.id as string;
+
+  const data = await getInvoices(user);
+
+  return (
+    <Card className="lg:col-span-2">
+      <CardHeader>
+        <CardTitle>Paid Invoices</CardTitle>
+        <CardDescription>
+          Invoices that have been paid in full by your clients.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Graph data={data} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import DashboardBlocks from "./_components/DashboardBlocks";
+import InvoiceGraph from "./_components/InvoiceGraph";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -12,6 +13,9 @@ export default async function Page() {
   return (
     <>
       <DashboardBlocks />
+      <div className="grid gap-4 lg:grid-cols-3 md:gap-8">
+        <InvoiceGraph />
+      </div>
     </>
   );
 }

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -139,7 +139,7 @@ const ChartTooltipContent = React.forwardRef<
       }
 
       const [item] = payload
-      const key = `${labelKey || item.dataKey || item.name || "value"}`
+      const key = `${labelKey || item?.dataKey || item?.name || "value"}`
       const itemConfig = getPayloadConfigFromPayload(config, item, key)
       const value =
         !labelKey && typeof label === "string"


### PR DESCRIPTION
- Implemented a Graph component to visualize paid invoices over the last 30 days.
- Integrated InvoiceGraph to fetch and transform data from Prisma.
- Sorted invoice data chronologically and aggregated daily totals.
- Enhanced dashboard with a visual representation of revenue trends.